### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,3 +8,4 @@ category=Device Control
 url=https://github.com/mpflaga/Arduino_Library-vs1053_for_SdFat
 architectures=avr
 includes=vs1053.h,SdFat.h,FreeStack.h
+depends=SdFat


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

NOTE: I did not add the TimerOne and SimpleTimer libraries to the dependencies list because these libraries are not needed with the default configuration of the VS1053 for use with SdFat library. However, I do think it would be reasonable to decide it was best to install all possible dependencies. If you prefer this, I'm happy to add those libraries to the dependencies list as well.